### PR TITLE
Bumps default dotnet SDK version

### DIFF
--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -9,7 +9,7 @@ FROM amidostacks/runner-pwsh
 
 ARG SONARSCANNER_VERSION=5.4.1
 ARG REPORTGENERATOR_VERSION=5.0.2
-ARG DOTNET_VERSION=6.0.200
+ARG DOTNET_VERSION=6.0.300
 ARG TOOLPATH="/usr/local/dotnet"
 
 # Upate the PATH environment variable so that the tool can be found

--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -15,6 +15,9 @@ ARG TOOLPATH="/usr/local/dotnet"
 # Upate the PATH environment variable so that the tool can be found
 ENV PATH="${TOOLPATH}:${PATH}"
 
+# Update the DOTNET_ROOT env var so that dotnet-sonarscanner can find it
+ENV DOTNET_ROOT=/usr/bin
+
 RUN apt-get update && apt-get -y install curl
 
 # Install the dotnet framework


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Bumps default dotnet SDK version.

## 🤔 Why

Required for compatibility.

## 🛠 How

Standard Dockerfile changes.

## 👀 Evidence

Already in use with recent builds

## 🕵️ How to test

Notes for QA
