### PR TITLE
Bumped software versions

### DIFF
--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -17,7 +17,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.4.1-unstable
+        - amidostacks/runner-pwsh
         - pwsh
         - -NoProfile
         - -Command

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -17,7 +17,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh
+        - amidostacks/runner-pwsh:0.4.3-stable
         - pwsh
         - -NoProfile
         - -Command

--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,8 @@
             "pdf-theme={{ basepath }}/build/conf/pdf/theme.yml",
             "pdf-fontsdir=\"{{ basepath }}/docs/styles/fonts;GEM_FONTS_DIR\"",
             "allow-uri-read",
-            "blockdiag=/usr/bin/blockdiag"
+            "blockdiag=/usr/bin/blockdiag",
+            "skip-front-matter"
         ]
     },
     "html": {
@@ -20,7 +21,8 @@
             "allow-uri-read",
             "toc=left",
             "java=/usr/bin/java",
-            "graphvizdot=/usr/bin/dot"
+            "graphvizdot=/usr/bin/dot",
+            "skip-front-matter"
         ]
     }
 }

--- a/docs/inspec_image.adoc
+++ b/docs/inspec_image.adoc
@@ -4,19 +4,26 @@ linkTitle: {name} Image
 
 === {name} Image
 
-Inspec is on the of the tools that we are working with to perform Infrastructure testing. Inspec is not easy to install in Alpine, because the main installer for it will not work with Alpine.
-
-To install an Ubuntu 22.04 image is used to install Inspec from using the installer script from Chef. The `amnidostacks/runner-pwsh` base image is then used and the `/opt/inspec` directory is copied from the Ubuntu image.
-
-In order to support this a GLIBC library is required and this has to be installed from an Alpine repo.
-
-NOTE: Alpine has been specifically built to have less moving parts and one of them the GLIBC library, musl is used instead as it is much smaller. It needs to be installed here to support Ruby.
+Inspec is on the of the tools that we are working with to perform Infrastructure testing. The official installer for Inspec will not work with Alpine OS, so to get around this the image installs Ruby and then installs the necessary packages and Gems to be able to install Inspec from a Gem.
 
 .OS Packages
+[cols="1,4,1",options="header",stripes=even]
+|===
+| Name | Description | Removed
+| ruby | Programming language used by Inspec | icon:times[]
+| ruby-dev | Development libraries required to build the native gems | icon:check[]
+| build-base | GCC and other tools required to build the native gems for Inspec | icon:check[]
+|===
+
+To install Inspec a number of Gem files are required. These are Inspec requirements and not ones that we have defined.
+
+.Gem Packages
 [cols="1,4",options="header",stripes=even]
 |===
 | Name | Description
-| ca-certificates | Common CA certificates
-| libstdc++ | GNU Standard C++ Library
-| libc-dev | Linux Kernel Headers for development
+| etc | Provides access to information typically stored in UNIX /etc directory.
+| bigdecimal | This library provides arbitrary-precision decimal floating-point number class.
+| io-console | Add console capabilities to IO instances.
 |===
+
+Once all of the necessary packages have been installed, those that have been installed just too compile certain libraries, are removed. Such packages are denoted as "Removed" in the OS Packages table.

--- a/image_definitions/golang/Dockerfile
+++ b/image_definitions/golang/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_REF=amidostacks/runner-pwsh
 FROM $IMAGE_REF as base
 
-FROM golang:1.19.2-alpine3.16
+FROM golang:1.21.3-alpine3.18
 
 COPY files/unittests.sh /usr/local/bin
 

--- a/image_definitions/inspec/Dockerfile
+++ b/image_definitions/inspec/Dockerfile
@@ -6,7 +6,8 @@ ARG INSPEC_VERSION=5.22.3
 
 # Update apk and install ruby
 RUN apk update && \
-    apk add ruby \
+    apk add gcompat \
+            ruby \
             build-base \
             ruby-dev
 

--- a/image_definitions/inspec/Dockerfile
+++ b/image_definitions/inspec/Dockerfile
@@ -2,14 +2,15 @@ ARG IMAGE_REF=amidostacks/runner-pwsh:latest
 FROM $IMAGE_REF
 
 # Set the version of Inspec to install
-ARG INSPEC_VERSION=5.22.3
+ARG INSPEC_VERSION=5.22.29
 
 # Update apk and install ruby
 RUN apk update && \
     apk add gcompat \
             ruby \
             build-base \
-            ruby-dev
+            ruby-dev \
+            linux-headers
 
 # Install the specified version of inspec
 RUN gem install etc && \
@@ -20,5 +21,6 @@ RUN gem install inspec-bin -v ${INSPEC_VERSION}
 
 # Remove packages that are no longer needed
 RUN apk del build-base \
-            ruby-dev
+            ruby-dev \
+            linux-headers
 

--- a/image_definitions/inspec/Dockerfile
+++ b/image_definitions/inspec/Dockerfile
@@ -1,46 +1,23 @@
-ARG IMAGE_REF=amidostacks/runner-pwsh
-FROM ubuntu:22.04 as base
-
-# ARG orgname=amidostacks
-ARG INSPEC_VERSION=5.22.3
-
-RUN apt-get update && apt-get install curl -y
-
-# -- Inspec for infrastructure testing
-RUN curl "https://omnitruck.chef.io/install.sh" -o "install.sh" && \
-    chmod +x ./install.sh && \
-    ./install.sh -P inspec -v ${INSPEC_VERSION} && \
-    rm install.sh
-
-# The ARG is repeated here because it needs to be refreshed from the initial setting
-# The behaviour of FROM and ARG is explained here - https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG IMAGE_REF
+ARG IMAGE_REF=amidostacks/runner-pwsh:latest
 FROM $IMAGE_REF
 
-ARG APK_GLIBC_VERSION=2.35-r1
-ARG APK_GLIBC_FILE="glibc-${APK_GLIBC_VERSION}.apk"
-ARG APK_GLIBC_BIN_FILE="glibc-bin-${APK_GLIBC_VERSION}.apk"
-ARG APK_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${APK_GLIBC_VERSION}"
+# Set the version of Inspec to install
+ARG INSPEC_VERSION=5.22.3
 
-# Install necessary packages
-RUN apk --no-cache add \
-    ca-certificates \
-    libstdc++ \
-    libc-dev
+# Update apk and install ruby
+RUN apk update && \
+    apk add ruby \
+            build-base \
+            ruby-dev
 
-# Get and install Glibc
-RUN curl -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-    && wget "${APK_GLIBC_BASE_URL}/${APK_GLIBC_FILE}"       \
-    && apk --force-overwrite --no-cache add "${APK_GLIBC_FILE}"               \
-    && wget "${APK_GLIBC_BASE_URL}/${APK_GLIBC_BIN_FILE}"   \
-    && apk --no-cache add "${APK_GLIBC_BIN_FILE}"           \
-    && rm glibc-*
+# Install the specified version of inspec
+RUN gem install etc && \
+    gem install bigdecimal && \
+    gem install io-console
+    
+RUN gem install inspec-bin -v ${INSPEC_VERSION}
 
-ENV PATH="${PATH}:/opt/inspec/bin"
-
-# Copy the inspec directory from the base image
-COPY --from=base /opt/inspec /opt/inspec
-
-
-
+# Remove packages that are no longer needed
+RUN apk del build-base \
+            ruby-dev
 


### PR DESCRIPTION
## 📲 What

Bumped the version of Golang and Inspec in the appropriate images.

## 🤔 Why

Needed a later version of Golang to build the `stacks-cli` to take advantage of some new functionality.

## 🛠 How

Updated the based image that is being used when creating the Golang image:

`FROM golang:1.21.3-alpine3.18`

Updated the Inspec version argument in the Inspec image:

```
# Set the version of Inspec to install
ARG INSPEC_VERSION=5.22.29
```

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA
