### PR TITLE
Corrected path statement for Golang image

### DIFF
--- a/image_definitions/golang/Dockerfile
+++ b/image_definitions/golang/Dockerfile
@@ -33,7 +33,7 @@ RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache \
 COPY --from=base /opt/microsoft /opt/microsoft
 COPY --from=base /modules/AmidoBuild /modules/AmidoBuild
 
-ENV PATH="${PATH}:/opt/microsoft/powershell/7/pwsh"
+ENV PATH="${PATH}:/opt/microsoft/powershell/7"
 
 
 


### PR DESCRIPTION
## 📲 What

Corrected PATH env var to the OS for PowerShell

## 🤔 Why

The path had the command on it, which meant that the image was looking for `pwsh` in `/opt/microsoft/powershell/7/pwsh`

## 🛠 How

Corrected the statement in the Dockerfile so the PATHJ env var is set correctly.

```
ENV PATH="${PATH}:/opt/microsoft/powershell/7"
```

## 👀 Evidence

Pwsh is now found correctly in the image

![image](https://github.com/Ensono/stacks-docker-images/assets/791658/d834109f-6451-4847-87ec-aa2fb911d800)


## 🕵️ How to test

Notes for QA
