### PR TITLE
Added sonar scanner CLI to image

### DIFF
--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -17,7 +17,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.4.20-stable
+        - amidostacks/runner-pwsh:0.4.48-stable
         - pwsh
         - -NoProfile
         - -Command

--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -2,6 +2,7 @@ ARG orgname=amidostacks
 ARG IMAGE_REF=amidostacks/runner-pwsh-java
 FROM $IMAGE_REF
 
+ARG SONARSCANNER_CLI_VERSION=5.0.1.3006
 ARG SONARSCANNER_VERSION=5.14
 ARG REPORTGENERATOR_VERSION=5.1.26
 ARG DOTNET_VERSION=6.0.300
@@ -21,3 +22,13 @@ RUN curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
 # Install necessary dotnet tools
 RUN dotnet tool install dotnet-sonarscanner --version ${SONARSCANNER_VERSION} --tool-path ${TOOLPATH} && \
     dotnet tool install dotnet-reportgenerator-globaltool --version ${REPORTGENERATOR_VERSION} --tool-path ${TOOLPATH}
+
+# Install SonarScanner CLI
+RUN curl --insecure -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONARSCANNER_CLI_VERSION}-linux.zip -o /opt/sonarscanner.zip && \
+    cd /opt && \
+    unzip sonarscanner.zip && \
+    rm sonarscanner.zip && \
+    rm -rf sonar-scanner-${SONARSCANNER_CLI_VERSION}-linux/jre && \
+    sed -i 's/use_embedded_jre=true/use_emebdded_jre=false/g' sonar-scanner-${SONARSCANNER_CLI_VERSION}-linux/bin/sonar-scanner && \
+    chmod -R 777 * && \
+    ln -sf /opt/sonar-scanner-${SONARSCANNER_CLI_VERSION}-linux/bin/sonar-scanner /usr/local/bin


### PR DESCRIPTION
## 📲 What

Added the Sonar Scanner CLI to the .NET image

## 🤔 Why

The image that was being used was basked on OpenJDK 11 which was deprecated by Sonar Cloud on 15/11/23. The repo that it is in has been archived as we do not create builds out of it now.

The Dotrnet image was chosen as it is based on the Java image and has Azul 17 installed.

## 🛠 How

Added the the installation of the CLI tool to the end of the Dockerfile

## 👀 Evidence

The status of the analsys by SonarCloud is now added to PRs as expected

![image](https://github.com/Ensono/stacks-docker-images/assets/791658/88d8ff13-53c0-44b4-8e4b-5f30526c7f39)


## 🕵️ How to test

Notes for QA
