### PR TITLE
fix: Bumps IR to latest version

### DIFF
--- a/image_definitions/base/Dockerfile
+++ b/image_definitions/base/Dockerfile
@@ -34,7 +34,7 @@ FROM mcr.microsoft.com/powershell:${IMAGE_TAG}
 
 # Add the arguments for the apps to install in the base image
 ARG TERRAFORM_VERSION=1.5.1
-ARG AMIDOBUILD=v0.0.262
+ARG AMIDOBUILD=v0.0.265
 ARG TASKCTL_VERSION=1.4.2
 ARG KUBE_VERSION=v1.23.14
 ARG AZURE_CLI_VERSION=2.48.1


### PR DESCRIPTION
What?

Bumped version of POwerShell module to latest version

Why?

New features have been added to the module that are required in container execution runs.

How?

Modified the default value of the AMIDOBUILD arg in the base Dockerfile file.