### PR TITLE
Add portal-cli to kong tools

### DIFF
--- a/image_definitions/kong/Dockerfile
+++ b/image_definitions/kong/Dockerfile
@@ -2,7 +2,8 @@ ARG IMAGE_REF=amidostacks/runner-pwsh
 
 FROM $IMAGE_REF
 
-ARG DECK_VERSION=1.30.0
+ARG DECK_VERSION=1.34.0
+ARG PORTAL_CLI_VERSION=0.0.1-alpha004
 
 # -- Deck
 RUN export ARCH="$(uname -m)" \
@@ -10,3 +11,11 @@ RUN export ARCH="$(uname -m)" \
     && curl -L "https://github.com/kong/deck/releases/download/v${DECK_VERSION}/deck_${DECK_VERSION}_linux_${ARCH}.tar.gz" -o /tmp/deck.tar.gz \
     && tar zxf /tmp/deck.tar.gz -C /usr/bin deck \
     && chmod +x /usr/bin/deck
+
+# -- Portal CLI
+RUN export ARCH="$(uname -m)" \
+    export MUSL="$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)" \
+    && if [[ ${ARCH} == "x86_64" ]]; then if [[ -n ${MUSL} ]]; then export ARCH="musl-x64"; else export ARCH="x64"; fi; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi \
+    && curl -L "https://github.com/AButler/kong-portal-cli/releases/download/v${PORTAL_CLI_VERSION}/portal-cli-linux-${ARCH}.tar.gz" -o /tmp/portal-cli.tar.gz \
+    && tar zxf /tmp/portal-cli.tar.gz -C /usr/bin portal-cli \
+    && chmod +x /usr/bin/portal-cli


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Adds the `portal-cli` tool to the Kong image

## 🤔 Why

`deck` does not allow syncing of API Products, API Product Versions, API Product Documentation or Portal settings so this tool has been created to allow syncing

## 🛠 How

Added the `portal-cli` tool to the docker image for Kong

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA
