### PR TITLE
fix: Bumps tf to latest 1.5.x (1.5.7)

### DIFF
--- a/image_definitions/base/Dockerfile
+++ b/image_definitions/base/Dockerfile
@@ -33,7 +33,7 @@ RUN (cd /usr/local/lib/aws-cli; for a in *.so*; do test -f /lib/$a && rm $a; don
 FROM mcr.microsoft.com/powershell:${IMAGE_TAG}
 
 # Add the arguments for the apps to install in the base image
-ARG TERRAFORM_VERSION=1.5.1
+ARG TERRAFORM_VERSION=1.5.7
 ARG ENSONOBUILD=v1.0.51
 ARG TASKCTL_VERSION=1.4.2
 ARG KUBE_VERSION=v1.23.14


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Bumps TF to 1.5.7

## 🤔 Why

Some newer TF versions put stuff into the state that older TFs didn't understand. Also good to keep up-to-date.

## 🛠 How

## 👀 Evidence

## 🕵️ How to test
