### PR TITLE
feat: bumps EIR to latest version, dotnet warn

### DIFF
--- a/image_definitions/base/Dockerfile
+++ b/image_definitions/base/Dockerfile
@@ -34,7 +34,7 @@ FROM mcr.microsoft.com/powershell:${IMAGE_TAG}
 
 # Add the arguments for the apps to install in the base image
 ARG TERRAFORM_VERSION=1.5.7
-ARG ENSONOBUILD=v1.0.51
+ARG ENSONOBUILD=v1.1.2
 ARG TASKCTL_VERSION=1.4.2
 ARG KUBE_VERSION=v1.23.14
 ARG AZURE_CLI_VERSION=2.48.1


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Bumps EIR to latest version for the Dotnet Warn changes and Ensono Tenant migration

## 🤔 Why

Missing tests in stacks-dotnet for Component and Contract cause the build to fail on newer images. See: https://github.com/Ensono/stacks-dotnet/actions/runs/10270240997/job/28417570632?pr=413#logs

## 🛠 How

## 👀 Evidence

## 🕵️ How to test