### PR TITLE
fix: transfers docs to image jobs

### DIFF
--- a/build/azDevOps/docker-images.yml
+++ b/build/azDevOps/docker-images.yml
@@ -20,6 +20,7 @@ parameters:
       - stage: FoundationPowerShell
         displayName: "[CONTAINER] Foundation - PowerShell"
         dependsOn:
+          - Documentation
           - Infrastructure
         taskName: build:foundation:powershell
         imageName: ensono/eir-foundation-powershell
@@ -27,6 +28,7 @@ parameters:
       - stage: FoundationBuilder
         displayName: "[CONTAINER] Foundation - Builder"
         dependsOn:
+          - Documentation
           - FoundationPowerShell
         taskName: build:foundation:builder
         imageName: ensono/eir-foundation-builder
@@ -196,7 +198,7 @@ stages:
                   script: |
                     exit
 
-  - stage: documentation
+  - stage: Documentation
     displayName: Documentation
     jobs:
       - job: GenerateDocumentation
@@ -223,11 +225,18 @@ stages:
               artifactName: docs
 
           - task: Bash@3
-            displayName: Create image Overview
+            displayName: Create Image Overview
             inputs:
               targetType: inline
               script: |
                 taskctl generate:docker:overview
+
+          # Upload the overview documentation
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Image Overview Documentation
+            inputs:
+              pathToPublish: $(Build.SourcesDirectory)/markdown
+              artifactName: markdown-docs
 
   - ${{ each stage in parameters.stages }}:
       - stage: ${{ stage.stage }}
@@ -243,6 +252,11 @@ stages:
             displayName: Build Image - amd64
             pool: $(build_pool_amd64)
             steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifactName: markdown-docs
+                  targetPath: $(System.DefaultWorkingDirectory)
+
               - template: templates/configure_agent.yml
                 parameters:
                   TaskctlVersion: $(TaskctlVersion)
@@ -264,6 +278,11 @@ stages:
             displayName: Build Image - arm64
             pool: $(build_pool_arm64)
             steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifactName: markdown-docs
+                  targetPath: $(System.DefaultWorkingDirectory)
+
               - template: templates/configure_agent.yml
                 parameters:
                   TaskctlVersion: $(TaskctlVersion)

--- a/build/scripts/Build-DockerImage.ps1
+++ b/build/scripts/Build-DockerImage.ps1
@@ -87,6 +87,7 @@ if ($registry -ieq "docker.io") {
 
     # get the path to the readme file from the args that have been set
     $status = $arguments -match '-f\s\./([a-zA-Z/\.-]*)/Dockerfile\.ubuntu'
+    $status = $status -replace "src/definitions", "markdown"
     if ($status) {
 
         $path_parts = $Matches[1] -split "/"

--- a/build/scripts/Set-DockerOverview.ps1
+++ b/build/scripts/Set-DockerOverview.ps1
@@ -8,7 +8,7 @@ param (
 
     [string]
     # Output root
-    $output = "/app/src/definitions",
+    $output = "/app/markdown",
 
     [string]
     # Temporary directory
@@ -24,9 +24,9 @@ $base = $base | Resolve-Path
 
 # Iterate around the overviews files that have been found
 foreach ($overview in $overviews) {
-
-    # set the definition name
     $definition_name = [IO.Path]::GetFileNameWithoutExtension($overview)
+
+    New-Item -ItemType Directory -Path $definition_name
 
     # Determine the paths that are needed for the conversions
     $db_path = "{0}.xml" -f [IO.Path]::Combine($temp, $definition_name)


### PR DESCRIPTION
# Pull Request Template

## 📲 What

transfers docs to image jobs

## 🤔 Why

Docs aren't available on the image builds otherwise and they crash

## 🛠 How

## 👀 Evidence

![image](https://github.com/user-attachments/assets/80399c9b-8f60-4335-83a7-5b52af1a9481)


## 🕵️ How to test