### PR TITLE
feat: ensure gpg, and add sonar-scanner to java

### DIFF
--- a/build/azDevOps/docker-images.yml
+++ b/build/azDevOps/docker-images.yml
@@ -126,6 +126,7 @@ parameters:
       - stage: AzureData
         displayName: "[CONTAINER] Azure Data"
         dependsOn:
+          - FoundationTools
           - FoundationAzureCli
         taskName: build:data
         imageName: ensono/eir-azure-data

--- a/src/definitions/asciidoctor/Dockerfile.ubuntu
+++ b/src/definitions/asciidoctor/Dockerfile.ubuntu
@@ -2,11 +2,9 @@ ARG IMAGE_TAG=0.0.1-workstation
 ARG REGISTRY=docker.io
 ARG ORG=ensono
 
-# Get a copy of Node from the Node image, so that it is 
+# Get a copy of Node from the Node image, so that it is
 # available to run mermaid
 FROM ${REGISTRY}/${ORG}/eir-nodejs:${IMAGE_TAG} AS node
-
-ARG NODE_VERSION=v20.16.0
 
 FROM ${REGISTRY}/${ORG}/eir-java:${IMAGE_TAG}
 
@@ -25,11 +23,14 @@ ARG ASCIIDOCTOR_REVEALJS_VERSION=5.1.0
 ARG ASCIIDOCTOR_VERSION=2.0.21
 ARG ERD_VERSION=2.0.0
 ARG HUGO_VERSION=0.123.7
-ARG NODE_VERSION=v20.16.0
 ARG PANDOC_VERSION=3.1.12.2
 
+# NOTE: This must be a version in the Node Dockerfile `src/definitions/node/Dockerfile.ubuntu`
+ARG DEFAULT_NODE_VERSION=v20.17.0
+
 # Copy Node from the node Image
-COPY --from=node /root/.nvm/versions/node/${NODE_VERSION} /usr/local/node
+# NOTE: The path to the versions is set by `NVM_ROOT` in the Node Dockerfile `src/definitions/node/Dockerfile.ubuntu`
+COPY --from=node /usr/local/nvm/versions/node/${DEFAULT_NODE_VERSION} /usr/local/node
 
 # Update the PATH so some tools are accessible
 ENV PATH="${PATH}:/usr/local/pandoc/bin:/usr/local/node/bin"
@@ -44,5 +45,3 @@ RUN chmod +x /usr/local/bin/install.bash && /usr/local/bin/install.bash
 
 # Copy in the AsciiDoctor library
 COPY files/lib /usr/local/ensono/lib
-
-

--- a/src/definitions/foundation/powershell/files/install.bash
+++ b/src/definitions/foundation/powershell/files/install.bash
@@ -9,6 +9,9 @@ set -euxo pipefail
 apt-get update
 apt-get install -y libicu70 lsb-release curl git
 
+# Containers often need this, such as signing Java Packages for publishing
+apt-get install -y gpg
+
 # Get the ARCH of the enviornment
 . /usr/local/bin/platform.bash
 

--- a/src/definitions/foundation/tools/files/install.bash
+++ b/src/definitions/foundation/tools/files/install.bash
@@ -52,7 +52,7 @@ export PATH="${PATH}:/usr/local/tenv/bin"
 IFS=","
 for TFVERSION in ${TERRAFORM_VERSION}; do
     echo "Installing: Terraform [${TFVERSION})]"
-    
+
     tenv tf install ${TFVERSION}
 done
 

--- a/src/definitions/infrastructure/Dockerfile.ubuntu
+++ b/src/definitions/infrastructure/Dockerfile.ubuntu
@@ -24,7 +24,7 @@ COPY --from=tools /usr/local/envsubst /usr/local/envsubst
 
 # Copy the Tenv tool and the install Terraform versions
 COPY --from=tools /usr/local/tenv /usr/local/tenv
-COPY --from=tools /root/.tenv /root/.tenv
+COPY --from=tools /root/.tenv /usr/local/tenv/.tenv
 
 # Copy all modules from the tools image
 COPY --from=tools /usr/local/share/powershell/Modules /usr/local/share/powershell/Modules
@@ -40,3 +40,4 @@ RUN chmod +x /usr/local/bin/install.bash && /usr/local/bin/install.bash
 
 # Set the PATH so that the tools can be accessed
 ENV PATH="${PATH}:/usr/local/kubectl/bin:/usr/local/helm/bin:/usr/local/terraform/bin:/usr/local/ghcli/bin:/usr/local/kluctl/bin:/usr/local/kustomize/bin:/usr/local/jq/bin:/usr/local/terrascan/bin:/usr/local/docker/bin:/usr/local/envsubst/bin:/usr/local/tenv/bin"
+ENV TENV_ROOT="/usr/local/tenv/.tenv"

--- a/src/definitions/infrastructure/files/install.bash
+++ b/src/definitions/infrastructure/files/install.bash
@@ -21,3 +21,6 @@ unzip awscliv2.zip
 pip3 install -r /tmp/requirements.txt
 
 rm /tmp/requirements.txt
+
+# Ensure TENV directory is writable to prevent warnings about writing to the 'last-use.txt'
+chmod -R a+w /usr/local/tenv/.tenv

--- a/src/definitions/java/Dockerfile.ubuntu
+++ b/src/definitions/java/Dockerfile.ubuntu
@@ -14,6 +14,7 @@ FROM ${REGISTRY}/${ORG}/eir-foundation-powershell:${IMAGE_TAG}
 ARG JAVA_MAJOR
 
 ARG MAVEN_VERSION=3.8.8
+ARG SONAR_SCANNER_VERSION=6.1.0.4477
 
 # Copy Java from the java image into this image
 COPY --from=java /usr/lib/jvm/zulu${JAVA_MAJOR} /usr/local/java/

--- a/src/definitions/java/files/install.bash
+++ b/src/definitions/java/files/install.bash
@@ -2,11 +2,25 @@
 
 set -euxo pipefail
 
-# Update Apt and install unzup
+# Update Apt and install unzip
 apt-get update
 apt-get install -y unzip
 
+BIN_LOCATION="/usr/local"
+
 # Install Maven
 curl --fail-with-body -L "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip" -o /tmp/maven.zip
-unzip /tmp/maven.zip -d /usr/local
+unzip /tmp/maven.zip -d "${BIN_LOCATION}"
 rm /tmp/maven.zip
+
+# Install Sonar Scanner CLI
+SONAR_DIRECTORY="sonar-scanner-${SONAR_SCANNER_VERSION}"
+ZIP_LOCATION="/tmp/${SONAR_DIRECTORY}.zip"
+SONAR_BINARY_LOCATION="/${BIN_LOCATION}/${SONAR_DIRECTORY}/bin/sonar-scanner"
+
+curl --fail-with-body -L "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip" -o "${ZIP_LOCATION}"
+unzip "${ZIP_LOCATION}" -d "${BIN_LOCATION}"
+chmod u+x "${SONAR_BINARY_LOCATION}"
+ln -s ${SONAR_BINARY_LOCATION} "${BIN_LOCATION}/bin/sonar-scanner"
+
+rm "${ZIP_LOCATION}"

--- a/src/definitions/node/Dockerfile.ubuntu
+++ b/src/definitions/node/Dockerfile.ubuntu
@@ -5,8 +5,11 @@ ARG ORG=ensono
 FROM ${REGISTRY}/${ORG}/eir-foundation-powershell:${IMAGE_TAG}
 
 # Specify the versions of software to install
-ARG NVM_VERSION=0.39.7
-ARG NODE_VERSIONS="v20.16.0,v18.20.2"
+ARG NVM_VERSION=0.40.1
+ARG PWSH_NVM_VERSION=2.5.4
+ARG NODE_VERSIONS="v20.17.0,v18.20.4"
+
+ENV NVM_ROOT="/usr/local/nvm"
 
 # Copy the necessary files to the image
 COPY files/install.bash /tmp/install.bash

--- a/src/definitions/node/Dockerfile.ubuntu
+++ b/src/definitions/node/Dockerfile.ubuntu
@@ -4,12 +4,15 @@ ARG ORG=ensono
 
 FROM ${REGISTRY}/${ORG}/eir-foundation-powershell:${IMAGE_TAG}
 
+ENV NVM_ROOT="/usr/local/nvm"
+# NOTE: This Node version is also used by ASCII Doctor `src/definitions/asciidoctor/Dockerfile.ubuntu`
+# If you change this, please update that file!
+ENV DEFAULT_NODE_VERSION="v20.17.0"
+
 # Specify the versions of software to install
 ARG NVM_VERSION=0.40.1
 ARG PWSH_NVM_VERSION=2.5.4
-ARG NODE_VERSIONS="v20.17.0,v18.20.4"
-
-ENV NVM_ROOT="/usr/local/nvm"
+ARG NODE_VERSIONS="v18.20.4,${DEFAULT_NODE_VERSION}"
 
 # Copy the necessary files to the image
 COPY files/install.bash /tmp/install.bash

--- a/src/definitions/node/files/install.bash
+++ b/src/definitions/node/files/install.bash
@@ -2,13 +2,16 @@
 
 set -euxo pipefail
 
+mkdir "${NVM_ROOT}"
+export NVM_DIR="${NVM_ROOT}"
+
 # Download and install the specified version of NVM
-curl --fail-with-body -L -o /tmp/nvm_install https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh
+curl --fail-with-body -L https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh -o /tmp/nvm_install
 chmod +x /tmp/nvm_install
 /tmp/nvm_install
+rm /tmp/nvm_install
 
 # Activate NVM
-export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
@@ -19,6 +22,8 @@ for node_version in $versions
 do
     nvm install $node_version
 done
+
+chmod -R a+w "${NVM_ROOT}"
 
 # Set the latest version of node as the default
 nvm alias default node

--- a/src/definitions/node/files/install.bash
+++ b/src/definitions/node/files/install.bash
@@ -25,5 +25,5 @@ done
 
 chmod -R a+w "${NVM_ROOT}"
 
-# Set the latest version of node as the default
-nvm alias default node
+# Set the default node version
+nvm alias default "${DEFAULT_NODE_VERSION}"

--- a/src/definitions/node/files/install.ps1
+++ b/src/definitions/node/files/install.ps1
@@ -15,21 +15,27 @@ Finally it updates the profile script to set the default version of Node to be u
 param (
     [string]
     # List of node versions that are installed
-    $Versions = $env:NODE_VERSIONS
+    $Versions = $env:NODE_VERSIONS,
+
+    [string]
+    $NvmRoot = $env:NVM_ROOT,
+
+    [string]
+    $PwshNvmVersion = $env:PWSH_NVM_VERSION
 )
 
 # Split the Versions and get the default versions
 $default_version = $Versions.Split(",")[0]
 
 # Install the PSNvm module
-Install-Module -Name nvm -Force -AllowClobber
+Install-Module -Name nvm -Force -AllowClobber -RequiredVersion $PwshNvmVersion -Scope AllUsers
 
 # Set the location of the node versions that are installed
 # This is done using a file because the Set-NodeInstallPath from the module automatially
 # appends `.nvm` to the specified path.
-$settings = '{"InstallPath": "/root/.nvm/versions/node"}'
+$settings = "{`"InstallPath`": `"$NvmRoot/versions/node`"}"
 
-Set-Content -Path /root/.local/share/powershell/Modules/nvm/2.5.4/settings.json -Value $settings
+Set-Content -Path /usr/local/share/powershell/Modules/nvm/${PwshNvmVersion}/settings.json -Value $settings
 
 # Set the default version of node to be used
 # This is added to the end of the profile


### PR DESCRIPTION
# Pull Request Template

## 📲 What

 * Adds gpg to the foundation container
 * Adds `sonar-scanner` to the Java image, needed for running SonarCloud scans
 * Ensures stacks-data` image is built after Tools as it requires it (race condition)
 * Ensures the `.tenv` directory lives outside `/root` which can only be seen by root
 * Ensures nvm is set up and installed outside of the `/root` directory which can only be seen by root

## 🤔 Why

 * gpg is often used for hash checking etc and so it's best to have it on the top-most container
 * sonar-scanner is needed for Java
 *  Non-standard usage, like using inside AzDo explicitly breaks as they run under a different user, tenv and npm were susceptible to this. Until the Java stuff is moved to EIR this is a quick workaround

## 🛠 How

## 👀 Evidence

## 🕵️ How to test
