### PR TITLE
fix: fixes include which should be literal

### DIFF
--- a/docs/docker-definitions/asciidoctor.adoc
+++ b/docs/docker-definitions/asciidoctor.adoc
@@ -43,7 +43,7 @@ In addition to the above binaries and Ruby Gems, the image has been populated wi
 ----
 | 
 ----
-include::glob:*.adoc[]
+\include::glob:*.adoc[]
 ----
 
 |====


### PR DESCRIPTION
# Pull Request Template

## 📲 What

fix: fixes include which should be literal

## 🤔 Why

It's causing problems elsewhere (Independent Runner) which try to use the literal example as an include rather than a literal example...

## 🛠 How

## 👀 Evidence

`main`:
![image](https://github.com/user-attachments/assets/9657c3d6-f666-4c24-a7d2-ec2a5ba2bea9)

This PR:
![image](https://github.com/user-attachments/assets/7f2a8fa2-93aa-46df-b67c-eb3fb0757206)

## 🕵️ How to test

Notes for QA
